### PR TITLE
libvirt version bump to 8.1

### DIFF
--- a/virt-manager.rb
+++ b/virt-manager.rb
@@ -27,8 +27,8 @@ class VirtManager < Formula
   depends_on "vte3"
 
   resource "libvirt-python" do
-    url "https://libvirt.org/sources/python/libvirt-python-7.8.0.tar.gz"
-    sha256 "9d07416d66805bf1a17f34491b3ced2ac6c42b6a012ddf9177e0e3ae1b103fd5"
+    url "https://libvirt.org/sources/python/libvirt-python-8.1.0.tar.gz"
+    sha256 "a21ecfab6d29ac1bdd1bfd4aa3ef58447f9f70919aefecd03774613f65914e43"
   end
 
   resource "idna" do


### PR DESCRIPTION
With libvirt 7.8 I was getting errors:

```
    Missing type converters:
    virTypedParameterPtr:1
    ERROR: failed virDomainSetLaunchSecurityState
    error: command '/usr/local/Cellar/virt-manager/2.2.1_3/libexec/bin/python3.9' failed with exit code 1
    Running setup.py install for libvirt-python: finished with status 'error'
```

bumping libvirt to 8.1 resolved issue